### PR TITLE
Fix villager entity names for mods that show display name

### DIFF
--- a/src/main/resources/assets/morevillagers/lang/en_us.json
+++ b/src/main/resources/assets/morevillagers/lang/en_us.json
@@ -24,6 +24,14 @@
   "entity.minecraft.villager.morevillagers.florist": "Florist",
   "entity.minecraft.villager.morevillagers.hunter": "Hunter",
 
+  "entity.minecraft.villager.oceanographer": "Oceanographer",
+  "entity.minecraft.villager.netherian": "Netherologist",
+  "entity.minecraft.villager.woodworker": "Forester",
+  "entity.minecraft.villager.enderian": "Enderologist",
+  "entity.minecraft.villager.engineer": "Engineer",
+  "entity.minecraft.villager.florist": "Florist",
+  "entity.minecraft.villager.hunter": "Hunter",
+
   "Frequent Customer": "Frequent Customer",
   "Trade with every villager profession": "Trade with every villager profession",
   "Town Tourist": "Town Tourist",

--- a/src/main/resources/assets/morevillagers/lang/ru_ru.json
+++ b/src/main/resources/assets/morevillagers/lang/ru_ru.json
@@ -23,6 +23,14 @@
   "entity.minecraft.villager.morevillagers.engineer": "Инженер",
   "entity.minecraft.villager.morevillagers.florist": "Садовник",
   "entity.minecraft.villager.morevillagers.hunter": "Охотник",
+
+  "entity.minecraft.villager.oceanographer": "Океанограф",
+  "entity.minecraft.villager.netherian": "Незеролог",
+  "entity.minecraft.villager.woodworker": "Лесник",
+  "entity.minecraft.villager.enderian": "Эндолог",
+  "entity.minecraft.villager.engineer": "Инженер",
+  "entity.minecraft.villager.florist": "Садовник",
+  "entity.minecraft.villager.hunter": "Охотник",
   
   "Frequent Customer": "Постоянный клиент",
   "Trade with every villager profession": "Поторгуйтесь с крестьянином каждой профессии",

--- a/src/main/resources/assets/morevillagers/lang/zh_tw.json
+++ b/src/main/resources/assets/morevillagers/lang/zh_tw.json
@@ -20,4 +20,12 @@
   "entity.minecraft.villager.morevillagers.engineer": "工程學家",
   "entity.minecraft.villager.morevillagers.florist": "園藝匠",
   "entity.minecraft.villager.morevillagers.hunter": "捕獵人"
+
+  "entity.minecraft.villager.oceanographer": "海洋學家",
+  "entity.minecraft.villager.netherian": "地獄旅者",
+  "entity.minecraft.villager.woodworker": "木匠",
+  "entity.minecraft.villager.enderian": "終界旅者",
+  "entity.minecraft.villager.engineer": "工程學家",
+  "entity.minecraft.villager.florist": "園藝匠",
+  "entity.minecraft.villager.hunter": "捕獵人"
 }


### PR DESCRIPTION
Example, JustEnoughResources village trades tab that uses entity.getDisplayName():

![villager_before_after](https://user-images.githubusercontent.com/18539948/150848395-16066073-b8eb-4a4c-98bc-5b65600254ae.png)
