### PR TITLE
Fixed & improved Nether/End map advancements

### DIFF
--- a/src/main/resources/data/morevillagers/advancements/map_bastion.json
+++ b/src/main/resources/data/morevillagers/advancements/map_bastion.json
@@ -17,17 +17,32 @@
   },
   "criteria": {
     "hasmap": {
-      "trigger": "minecraft:inventory_changed",
+      "trigger": "minecraft:villager_trade",
       "conditions": {
+        "villager": {
+          "type": "minecraft:villager",
+          "nbt": "{VillagerData:{profession:\"minecraft:netherian\"}}"
+        },
         "item": {
-            "items": ["minecraft:filled_map"]
+          "items": [
+            "minecraft:filled_map"
+          ]
         }
       }
     },
-    "bastion": {
+    "endcity": {
       "trigger": "minecraft:location",
       "conditions": {
-        "feature": "bastion_remnant"
+        "feature": "bastion_remnant",
+        "player": {
+          "player": {
+            "advancements": {
+              "morevillagers:map_bastion": {
+                "hasmap": true
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/src/main/resources/data/morevillagers/advancements/map_endcity.json
+++ b/src/main/resources/data/morevillagers/advancements/map_endcity.json
@@ -17,8 +17,12 @@
   },
   "criteria": {
     "hasmap": {
-      "trigger": "minecraft:inventory_changed",
+      "trigger": "minecraft:villager_trade",
       "conditions": {
+        "villager": {
+          "type": "minecraft:villager",
+          "nbt": "{VillagerData:{profession:\"minecraft:enderian\"}}"
+        },
         "item": {
           "items": [
             "minecraft:filled_map"
@@ -29,7 +33,16 @@
     "endcity": {
       "trigger": "minecraft:location",
       "conditions": {
-        "feature": "endcity"
+        "feature": "endcity",
+        "player": {
+          "player": {
+            "advancements": {
+              "morevillagers:map_endcity": {
+                "hasmap": true
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/src/main/resources/data/morevillagers/advancements/recipes/blueprint_table.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/blueprint_table.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:blueprint_table"
+    ]
+  },
+  "criteria": {
+    "has_paper": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:paper"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:blueprint_table"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_paper",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/decayed_workbench.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/decayed_workbench.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:decayed_workbench"
+    ]
+  },
+  "criteria": {
+    "has_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:nether_bricks"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:decayed_workbench"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/gardening_table.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/gardening_table.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:gardening_table"
+    ]
+  },
+  "criteria": {
+    "has_flower": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "minecraft:flowers"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:gardening_table"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_flower",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/hunting_post.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/hunting_post.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:hunting_post"
+    ]
+  },
+  "criteria": {
+    "has_arrow": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:arrow"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:hunting_post"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_arrow",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/mining_bench.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/mining_bench.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:mining_bench"
+    ]
+  },
+  "criteria": {
+    "has_iron_pickaxe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_pickaxe"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:mining_bench"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_iron_pickaxe",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/oceanography_table.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/oceanography_table.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:oceanography_table"
+    ]
+  },
+  "criteria": {
+    "has_barrel": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:barrel"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:oceanography_table"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_barrel",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/purpur_altar.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/purpur_altar.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:purpur_altar"
+    ]
+  },
+  "criteria": {
+    "has_end_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:end_stone"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:purpur_altar"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_end_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/morevillagers/advancements/recipes/woodworking_table.json
+++ b/src/main/resources/data/morevillagers/advancements/recipes/woodworking_table.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "morevillagers:woodworking_table"
+    ]
+  },
+  "criteria": {
+    "has_leaves": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "minecraft:leaves"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "morevillagers:woodworking_table"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_leaves",
+      "has_the_recipe"
+    ]
+  ]
+}


### PR DESCRIPTION
They were bugged so you didn't need to obtain a map to trigger them. Now, you need to obtain a map specifically by trading with the correct villager type, and obtain the map BEFORE entering the structure type it leads to.